### PR TITLE
Create mobilecoin branch for nightly-2021-07-21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,11 @@ members = [
 ]
 
 [features]
-# Use `#[test_case]`-based test registration (only works on nightly when `custom_test_frameworks` feature is enabled).
-# Without that feature turned on, the default test registration method is to use `ctor` crate to create a global list
-# of all tests.
+
+# Use `#[test_case]`-based test registration. If this is disabled, datatest will use the `ctor` crate to create a
+# global list of all tests.
+#
+# Enabled by default, only takes effect on nightly and only works when custom_test_frameworks feature is enabled.
 test_case_registration = []
 
 # Use very, very, very sketchy way of intercepting a test runner on a stable Rust. Without that feature, there are two
@@ -49,7 +51,7 @@ test_case_registration = []
 unsafe_test_runner = ["region"]
 
 # Make this crate useable on stable Rust channel. Uses forbidden technique to allow usage of this crate on a stable
-# Rust compiler. This, however, does not bring any guarantees above "nighly" -- this crate can break at any time.
+# Rust compiler. This, however, does not bring any guarantees above "nightly" -- this crate can break at any time.
 subvert_stable_guarantees = []
 
-default = []
+default = ["test_case_registration"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ region = { version = "2.1.2", optional = true }
 [dev-dependencies]
 serde = { version = "1.0.84", features = ["derive"] }
 
+[build-dependencies]
+version_check = "0.9.3"
+
 [workspace]
 members = [
     "datatest-derive"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,29 @@
+extern crate version_check as rustc;
+
 fn main() {
-    #[cfg(feature = "subvert_stable_guarantees")]
-    println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
+    let subverted = cfg!(feature = "subvert_stable_guarantees");
+
+    if subverted {
+        // This will cease to work sometime between cargo 1.50 and 1.52. Nightly clippy
+        // --all-features at the time of writing warns that:
+        //
+        // warning: Cannot set `RUSTC_BOOTSTRAP=1` from build script of `datatest v0.6.4 (...)`
+        // note: Crates cannot set `RUSTC_BOOTSTRAP` themselves, as doing so would subvert the
+        // stability guarantees of Rust for your project.
+        println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
+    }
+
+    let nightly = rustc::is_feature_flaggable().unwrap_or(false);
+    if nightly {
+        println!("cargo:rustc-cfg=feature=\"rustc_is_nightly\"");
+    } else {
+        println!("cargo:rustc-cfg=feature=\"rustc_is_stable\"");
+        if !subverted {
+            println!("cargo:warning=attempting to compile datatest on stable without opting in to subvert_stable_guarantees feature; will fail");
+        }
+    }
+    // See src/runner.rs
+    if rustc::is_min_version("1.52.0").unwrap_or(false) {
+        println!("cargo:rustc-cfg=feature=\"rustc_test_TestOpts_filters_vec\"");
+    }
 }

--- a/datatest-derive/src/lib.rs
+++ b/datatest-derive/src/lib.rs
@@ -374,19 +374,17 @@ fn handle_common_attrs(func: &mut ItemFn, regular_test: bool) -> FuncInfo {
 }
 
 fn parse_should_panic(attr: &syn::Attribute) -> ShouldPanic {
-    if let Ok(meta) = attr.parse_meta() {
-        if let syn::Meta::List(list) = meta {
-            for item in list.nested {
-                match item {
-                    syn::NestedMeta::Meta(syn::Meta::NameValue(ref nv))
-                        if nv.path.is_ident("expected") =>
-                    {
-                        if let syn::Lit::Str(ref value) = nv.lit {
-                            return ShouldPanic::YesWithMessage(value.value());
-                        }
+    if let Ok(syn::Meta::List(list)) = attr.parse_meta() {
+        for item in list.nested {
+            match item {
+                syn::NestedMeta::Meta(syn::Meta::NameValue(ref nv))
+                    if nv.path.is_ident("expected") =>
+                {
+                    if let syn::Lit::Str(ref value) = nv.lit {
+                        return ShouldPanic::YesWithMessage(value.value());
                     }
-                    _ => {}
                 }
+                _ => {}
             }
         }
     }

--- a/src/interceptor.rs
+++ b/src/interceptor.rs
@@ -20,7 +20,7 @@ fn intercept_test_main_static() {
     unsafe {
         let diff_bytes = diff.to_le_bytes();
         let bytes = ptr as *mut u8;
-        let _handle = region::protect_with_handle(bytes, 5, region::Protection::WriteExecute)
+        let _handle = region::protect_with_handle(bytes, 5, region::Protection::WRITE_EXECUTE)
             .expect("failed to modify page protection to intercept `test_main_static`");
 
         std::ptr::write(bytes.offset(0), 0xe9);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ use std::path::Path;
 
 /// `datatest` test harness entry point. Should be declared in the test module, like in the
 /// following snippet:
-/// ```rust,norun
+/// ```rust,no_run
 /// datatest::harness!();
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,21 +137,25 @@ pub mod __internal {
     pub use crate::runner::{
         check_test_runner, register, RegistrationNode, RegularShouldPanic, RegularTestDesc,
     };
-    #[cfg(not(feature = "test_case_registration"))]
+    // i.e. no TCR, use ctor instead
+    #[cfg(not(all(feature = "rustc_is_nightly", feature = "test_case_registration")))]
     pub use datatest_derive::{data_ctor_internal, files_ctor_internal};
-    #[cfg(feature = "test_case_registration")]
+    // i.e. use TCR
+    #[cfg(all(feature = "rustc_is_nightly", feature = "test_case_registration"))]
     pub use datatest_derive::{data_test_case_internal, files_test_case_internal};
 }
 
 pub use crate::runner::runner;
 
-#[cfg(not(feature = "test_case_registration"))]
+// i.e. no TCR, use ctor instead
+#[cfg(not(all(feature = "rustc_is_nightly", feature = "test_case_registration")))]
 pub use datatest_derive::{
     data_ctor_registration as data, files_ctor_registration as files,
     test_ctor_registration as test,
 };
 
-#[cfg(feature = "test_case_registration")]
+// i.e. use TCR
+#[cfg(all(feature = "rustc_is_nightly", feature = "test_case_registration"))]
 pub use datatest_derive::{
     data_test_case_registration as data, files_test_case_registration as files,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(incomplete_features)]
 #![feature(specialization)]
 #![feature(termination_trait_lib)]
 //! Crate for supporting data-driven tests.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -256,7 +256,8 @@ fn real_name(name: &str) -> &str {
 fn adjust_for_test_name(opts: &mut crate::rustc_test::TestOpts, name: &str) {
     let real_test_name = real_name(name);
     // rustc 1.52.0 changes `filters` to accept multiple filters from the command line
-    #[cfg(feature = "rustc_test_TestOpts_filters_vec")] {
+    #[cfg(feature = "rustc_test_TestOpts_filters_vec")]
+    {
         if opts.filter_exact {
             if let Some(test_name) = opts.filters.iter_mut().find(|s| *s == real_test_name) {
                 test_name.push_str("::");
@@ -265,7 +266,8 @@ fn adjust_for_test_name(opts: &mut crate::rustc_test::TestOpts, name: &str) {
         }
     }
     // fallback for rust < 1.52
-    #[cfg(not(feature = "rustc_test_TestOpts_filters_vec"))] {
+    #[cfg(not(feature = "rustc_test_TestOpts_filters_vec"))]
+    {
         if opts.filter_exact && opts.filter.as_ref().map_or(false, |s| s == real_test_name) {
             if let Some(test_name) = opts.filter.as_mut() {
                 test_name.push_str("::");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -255,9 +255,23 @@ fn real_name(name: &str) -> &str {
 /// instead.
 fn adjust_for_test_name(opts: &mut crate::rustc_test::TestOpts, name: &str) {
     let real_test_name = real_name(name);
-    if opts.filter_exact && opts.filter.as_ref().map_or(false, |s| s == real_test_name) {
-        opts.filter_exact = false;
-        opts.filter = Some(format!("{}::", real_test_name));
+    // rustc 1.52.0 changes `filters` to accept multiple filters from the command line
+    #[cfg(feature = "rustc_test_TestOpts_filters_vec")] {
+        if opts.filter_exact {
+            if let Some(test_name) = opts.filters.iter_mut().find(|s| *s == real_test_name) {
+                test_name.push_str("::");
+                opts.filter_exact = false;
+            }
+        }
+    }
+    // fallback for rust < 1.52
+    #[cfg(not(feature = "rustc_test_TestOpts_filters_vec"))] {
+        if opts.filter_exact && opts.filter.as_ref().map_or(false, |s| s == real_test_name) {
+            if let Some(test_name) = opts.filter.as_mut() {
+                test_name.push_str("::");
+                opts.filter_exact = false;
+            }
+        }
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -178,6 +178,8 @@ fn render_files_test(desc: &FilesTestDesc, rendered: &mut Vec<TestDescAndFn>) {
                     // Cannot be used on stable: https://github.com/rust-lang/rust/issues/46488
                     allow_fail: false,
                     test_type: crate::test_type(desc.source_file),
+                    compile_fail: false,
+                    no_run: false,
                 },
                 testfn,
             };
@@ -222,6 +224,8 @@ fn render_data_test(desc: &DataTestDesc, rendered: &mut Vec<TestDescAndFn>) {
                 should_panic: ShouldPanic::No,
                 allow_fail: false,
                 test_type: crate::test_type(desc.source_file),
+                compile_fail: false,
+                no_run: false,
             },
             testfn,
         };
@@ -407,6 +411,8 @@ fn render_test_descriptor(
                     // FIXME: should support!
                     allow_fail: false,
                     test_type: crate::test_type(desc.source_file),
+                    compile_fail: false,
+                    no_run: false,
                 },
                 testfn: TestFn::StaticTestFn(desc.testfn),
             })

--- a/tests/datatest.rs
+++ b/tests/datatest.rs
@@ -1,7 +1,25 @@
-#![cfg(feature = "nightly")]
+//! cargo +nightly test                         # test_case_registration enabled
+//! cargo +nightly test --no-default-features   # no test_case_registration, uses ctor
+
+// self-testing config only:
+#![cfg(all(feature = "rustc_is_nightly"))]
+
 #![feature(custom_test_frameworks)]
 #![test_runner(datatest::runner)]
 
 // We want to share tests between "nightly" and "stable" suites. These have to be two different
 // suites as we set `harness = false` for the "stable" one.
 include!("tests/mod.rs");
+
+// Regular tests still work
+
+#[test]
+fn regular_test() {
+    println!("regular tests also work!");
+}
+
+#[test]
+fn regular_test_result() -> Result<(), Box<dyn std::error::Error>> {
+    println!("regular tests also work!");
+    Ok(())
+}

--- a/tests/datatest.rs
+++ b/tests/datatest.rs
@@ -3,7 +3,6 @@
 
 // self-testing config only:
 #![cfg(all(feature = "rustc_is_nightly"))]
-
 #![feature(custom_test_frameworks)]
 #![test_runner(datatest::runner)]
 

--- a/tests/datatest_stable.rs
+++ b/tests/datatest_stable.rs
@@ -1,19 +1,30 @@
-// We want to share tests between "nightly" and "stable" suites. These have to be two different
-// suites as we set `harness = false` for the "stable" one.
-include!("tests/mod.rs");
+//! cargo +stable test --features subvert_stable_guarantees
 
+// This test suite is configured with `harness = false` in Cargo.toml.
+// So we need to make sure it has a main function when testing nightly
+#[cfg(not(feature = "rustc_is_stable"))]
+fn main() {}
+// And uses the datatest harness when testing stable
+#[cfg(feature = "rustc_is_stable")]
 datatest::harness!();
 
-// Regular test have to use `datatest` variant of `#[test]` to work.
-use datatest::test;
+#[cfg(feature = "rustc_is_stable")]
+mod stable {
+    // Regular test have to use `datatest` variant of `#[test]` to work.
+    use datatest::test;
 
-#[test]
-fn regular_test() {
-    println!("regular tests also work!");
-}
+    // We want to share tests between "rustc_is_nightly" and "rustc_is_stable" suites. These have to be two different
+    // suites as we set `harness = false` for the "stable" one.
+    include!("tests/mod.rs");
 
-#[test]
-fn regular_test_result() -> Result<(), Box<dyn std::error::Error>> {
-    println!("regular tests also work!");
-    Ok(())
+    #[test]
+    fn regular_test() {
+        println!("regular tests also work!");
+    }
+
+    #[test]
+    fn regular_test_result() -> Result<(), Box<dyn std::error::Error>> {
+        println!("regular tests also work!");
+        Ok(())
+    }
 }

--- a/tests/datatest_stable_unsafe.rs
+++ b/tests/datatest_stable_unsafe.rs
@@ -1,6 +1,7 @@
-//! Run with: `cargo +stable test --features unsafe_test_runner --test datatest_stable_unsafe`
+//! cargo +stable test --features subvert_stable_guarantees,unsafe_test_runner
 
-#[cfg(feature = "unsafe_test_runner")]
+#![cfg(feature = "rustc_is_stable")]
+#![cfg(feature = "unsafe_test_runner")]
 
 // We want to share tests between "nightly" and "stable" suites. These have to be two different
 // suites as we set `harness = false` for the "stable" one.

--- a/tests/tests/mod.rs
+++ b/tests/tests/mod.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "stable")]
-use datatest::test;
-
 use serde::Deserialize;
 use std::fmt;
 use std::path::Path;

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "nightly")]
+#![cfg(feature = "rustc_is_nightly")]
 #![feature(non_ascii_idents)]
 #![feature(custom_test_frameworks)]
 #![test_runner(datatest::runner)]


### PR DESCRIPTION
This PR establishes a "mobilecoin" branch which we'll use to track this crate until it's use can be deprecated. This PR is also meant to fix the build on `nightly-2021-07-21`, and will be marked as "ready for review" when that is complete.